### PR TITLE
Remove `kit_id` from payload and modal

### DIFF
--- a/src/app/styles/_navigation.scss
+++ b/src/app/styles/_navigation.scss
@@ -250,6 +250,7 @@ $button-height: $segueWrapperHeight / 2.75;
       border: 2px solid $regalBlue;
     }
   }
+
   .forwardButton {
     height: $button-height;
     width: $button-height;
@@ -275,12 +276,4 @@ $button-height: $segueWrapperHeight / 2.75;
       visibility: hidden;
     }
   }
-}
-
-.advancedButton {
-  font-size: 16px;
-  position: absolute;
-  bottom: 10px;
-  right: 10px;
-  color: $text-white;
 }

--- a/src/app/wizard/services/platform.js
+++ b/src/app/wizard/services/platform.js
@@ -98,16 +98,6 @@ export function platform($rootScope, $cookies, SegueService, Restangular, platfo
           });
     }
 
-    function getKits(scope) {
-        return Restangular.all('kits')
-          .getList({'per_page': 1000})
-          // We add .plain() because we don't need full CRUD on Tags.
-          .then(function(fetchedKits){
-            return fetchedKits.plain();
-          });
-    }
-
-
     return {
         setSession: setSession,
         setAuth: setAuth,
@@ -123,7 +113,6 @@ export function platform($rootScope, $cookies, SegueService, Restangular, platfo
         listenToken: listenToken,
         resetPassword: resetPassword,
         getTags: getTags,
-        getKits: getKits
     };
 
 }

--- a/src/app/wizard/wizard.controller.js
+++ b/src/app/wizard/wizard.controller.js
@@ -8,7 +8,6 @@ export function wizardController($scope, $location, $sce, $window, $timeout, Seg
         device_token: session.device_token,
         description: 'Smart Citizen Kit 2.1 with Urban Sensor Board',
         exposure: 'outdoor',
-        kit_id: 26
     };
 
     $scope.proposed_user_tags_array = [];
@@ -312,79 +311,6 @@ export function wizardController($scope, $location, $sce, $window, $timeout, Seg
         };
         $scope.modalContent = data;
         $rootScope.$broadcast('modal');
-    };
-
-    /** -- MODAL-- **/
-
-    $scope.modalClick = function() {
-        $scope.modalClass = 'out';
-        $timeout(function() {
-            $scope.modalClass = 'hidden';
-            $rootScope.$broadcast('modalClosed'); // This starts the light
-        }, 500);
-    };
-    $scope.modalButtonClick = function() {
-        switch ($scope.modalContent.action) {
-            case 'email':
-                $window.open('mailto:feedback-4873-IVVSumgXA4EEA4e7blwZvyE2sshIpRRK@feedback.doorbell.io?Subject=MakingSense Support [' + $scope.onboarding_session + ']', '_blank');
-                break;
-            case 'retry':
-                $scope.seque;
-                break;
-            case 'restart':
-                $state.go('wizard.landing');
-                break;
-            default:
-                $scope.seque;
-                break;
-        }
-    };
-
-    $rootScope.$on('modal', function() {
-        console.log('modal');
-        $scope.modalClass = 'showing';
-    });
-
-    /** -- ADVANCED MODAL-- **/
-
-    $scope.kit = null;
-    $scope.kits = null;
-
-    $scope.loadKits = function() {
-        return platform.getKits().then(function(kits){
-            kits.sort((a, b) => (a.id > b.id) ? 1 : -1)
-            $scope.kits = kits;
-        })
-    }
-
-    $scope.$watch('kit', function () {
-        if($scope.kit && $scope.kit.id) {
-            $scope.submittedData.deviceData.kit_id = $scope.kit.id;
-        }
-    });
-
-    $scope.saveAdvancedSettings = function() {
-        platform.updateDevice($scope.submittedData.deviceData).then(function(){
-            $scope.hideAdvancedModal();
-        });
-    };
-
-    $scope.showAdvancedModal = function(){
-        $scope.tempBlock = true;
-        $scope.modalBox = 'green';
-        $scope.advancedModalClass = 'showing';
-    };
-
-    /** Prevents click inside modal to close it **/
-    $scope.preventHideAdvancedModal = function(event) {
-        event.stopPropagation();
-    };
-
-    $scope.hideAdvancedModal = function() {
-        $scope.advancedModalClass = 'out';
-        $timeout(function() {
-            $scope.advancedModalClass = 'hidden';
-        }, 500);
     };
 
     Restangular.setErrorInterceptor(function(response, deferred, responseHandler) {

--- a/src/app/wizard/wizard.html
+++ b/src/app/wizard/wizard.html
@@ -32,8 +32,6 @@
             </svg>
 
             <span id="segueContent">{{ payload.segueButton | translate }}</span>
-
-
         </button>
         <div class="spinnerWrapper" ng-class="spinnerControl">
             <svg class="spinner" width="65px" height="65px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
@@ -55,10 +53,6 @@
     </div>
 </div>
 
-<div class="advancedButton" ng-if="!submittedData.deviceData.id">
-    <a ng-click="showAdvancedModal()">🛠️</a>
-</div>
-
 <div id="modal" ng-class="modalClass" layout="column" layout-align="center center" flex="grow" ng-click="modalClick()">
     <div id="modalContent" layout="column" layout-align="center center" layout-padding layout-margin>
         <div id="modalBox" ng-class="modalBox" layout-gt-sm="row" layout-align-sm="center center">
@@ -73,37 +67,6 @@
         </div>
         <div ng-if="modalContent.button" id="modalLink">
             <button id="modalButton" ng-click="modalButtonClick()" ng-class="modalButton">{{ modalContent.button | translate }}</button>
-        </div>
-    </div>
-</div>
-
-<div id="advanced-modal" ng-class="advancedModalClass" layout="column" layout-align="center center" flex="grow" ng-click="hideAdvancedModal()">
-    <div ng-click="preventHideAdvancedModal($event);" id="modalContent" layout="column" layout-align="center center" layout-padding layout-margin>
-        <div id="modalBox" ng-class="modalBox">
-
-            <button ng-click="hideAdvancedModal()" class="close">
-                <svg id='closeSVG' width="36px" height="40px" viewBox="8 10 36 49" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                    <defs></defs>
-                    <text id="close" stroke="none" fill="none" font-family="SSStandard, SS Standard" font-size="30" font-weight="normal">
-                        <tspan x="8" y="48" fill="#ffffff">close</tspan>
-                    </text>
-                </svg>
-            </button>
-
-            <div>
-                <h2>Advanced Kit Selection 🛠️</h2>
-                <p>Hey! If you don't know why you are here don't mess with it</p>
-                <md-select placeholder="Select your kit" ng-model="kit" md-on-open="loadKits()">
-                    <md-option ng-value="kit" ng-repeat="kit in kits">#{{kit.id}} {{kit.name}}</md-option>
-                </md-select>
-                <p ng-if="kit.description" class="md-caption">
-                    <span style="text-decoration: underline"> {{kit.description}}</span> can measure:<br> <span style="color: white; font-size: 19px;" ng-repeat="sensor in kit.sensors">{{$first ? '' : $last ? ' and ' : ', '}}{{sensor.measurement.name }}</span>
-                </p>
-                <p style="color: white; font-size: 18px; font-style: italic;" ng-if="kit.description" class="md-caption">
-                    This is the complete sensor list: <br> <span ng-repeat="sensor in kit.sensors">{{$first ? '' : $last ? ' and ' : ', '}} {{sensor.name}} ({{sensor.unit}})</span>
-                </p>
-                <button id="advancedModalButton" ng-click="saveAdvancedSettings()">Save</button>
-            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR will go with the https://github.com/fablabbcn/smartcitizen-api/pull/246 deployment.
It removes the `kit_id` on the payload and the advanced kit selection modal.