### PR TITLE
Clear the geolocation watch after location is set

### DIFF
--- a/src/app/wizard/location/location.controller.js
+++ b/src/app/wizard/location/location.controller.js
@@ -9,6 +9,7 @@ export function locationController($scope, uiGmapIsReady, $geolocation, scopePay
 
     var tagsList = [];
     var tagsState = [];
+    let geopositionId;
 
     for(var index = 0; index < tags.length; index++) {
         var name = tags[index].name;
@@ -33,7 +34,7 @@ export function locationController($scope, uiGmapIsReady, $geolocation, scopePay
 
     AnimationService.animate(scopePayload.template);
 
-    $geolocation.watchPosition({
+    geopositionId = $geolocation.watchPosition({
         timeout: 50,
         maximumAge: 25,
         enableHighAccuracy: true
@@ -97,6 +98,7 @@ export function locationController($scope, uiGmapIsReady, $geolocation, scopePay
         };
 
         setSensorPosition($scope.$parent.map.marker.location);
+        $geolocation.clearWatch(geopositionId);
     }
 
     function setSensorPosition(position) {


### PR DESCRIPTION
This PR fixes a small bug on the current onboarding in which the location pin was not reset after the:

```
geolocation.watchPosition({
        timeout: 50,
        maximumAge: 25,
        enableHighAccuracy: true
    });
```

Set the location for the first time. Once the location is set, it then clear the `watcher` to avoid coming back to the location. This also prevents the "Check location" issue.